### PR TITLE
Dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,17 +36,20 @@
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",
     "json-loader": "^0.5.4",
-    "jupyter-js-widgets": "file:../jupyter-js-widgets",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
     "babel-preset-es2015": "^6.6.0",
     "node-uuid": "^1.4.7",
     "enchannel": "^1.1.0",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "rxjs": "^5.0.0-beta.6"
+  },
+  "peerDependencies": {
+    "rxjs": "^5.0.0-beta.6"
   },
   "dependencies": {
-    "@reactivex/rxjs": "^5.0.0-beta.2",
-    "jupyter-js-services": "^0.5.5"
+    "jupyter-js-services": "^0.5.5",
+    "jupyter-js-widgets": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
     "babel-preset-es2015": "^6.6.0",
-    "node-uuid": "^1.4.7",
+    "uuid": "^2.0.2",
     "enchannel": "^1.1.0",
     "rimraf": "^2.5.2",
     "rxjs": "^5.0.0-beta.6"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const rxjs = require('@reactivex/rxjs');
+const rxjs = require('rxjs/Rx');
 import { listRunningKernels, connectToKernel, startNewKernel, getKernelSpecs } from 'jupyter-js-services';
 
 /**

--- a/src/web.js
+++ b/src/web.js
@@ -2,7 +2,7 @@
 const baseUrl = prompt('baseUrl', 'http://localhost:8888');
 const domain = baseUrl.split('://').slice(1).join('://');
 const wsUrl = prompt('wsUrl', `ws://${domain}`);
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const enchannel = require('enchannel');
 
 // Create a connection options object


### PR DESCRIPTION
Closes #2 

This package was still WIP (while waiting on `jupyter-js-widgets` I imagine), so I made a few changes to bring it up to speed:

* Switch to `rxjs@5.0.0-beta.6`
* `node-uuid` --> `uuid`
* pin to `jupyter-js-widgets`